### PR TITLE
Add the possibility to include helm charts in the generated csar file

### DIFF
--- a/vnfsdk_pkgtools/cli/__main__.py
+++ b/vnfsdk_pkgtools/cli/__main__.py
@@ -76,6 +76,9 @@ def parse_args(args_list):
         help='Output CSAR zip destination',
         required=True)
     csar_create.add_argument(
+        '--helm',
+        help='Helm entry definition file relative to service template directory')
+    csar_create.add_argument(
         '--manifest',
         help='Manifest file relative to service template directory')
     csar_create.add_argument(

--- a/vnfsdk_pkgtools/packager/csar.py
+++ b/vnfsdk_pkgtools/packager/csar.py
@@ -31,6 +31,7 @@ META_CSAR_VERSION_VALUE = '1.1'
 META_CREATED_BY_KEY = 'Created-By'
 META_CREATED_BY_VALUE = 'ONAP'
 META_ENTRY_DEFINITIONS_KEY = 'Entry-Definitions'
+META_ENTRY_HELM_DEFINITIONS_KEY = 'Entry-Helm-Definitions'
 META_ENTRY_MANIFEST_FILE_KEY = 'Entry-Manifest'
 META_ENTRY_HISTORY_FILE_KEY = 'Entry-Change-Log'
 META_ENTRY_TESTS_DIR_KEY = 'Entry-Tests'
@@ -84,6 +85,13 @@ def write(source, entry, destination, logger, args):
                    msg='This commands generates a meta file for you. Please '
                        'remove the existing metafile.',
                    check_for_non=True)
+
+    if(args.helm):
+        check_file_dir(root=source,
+                       entry=args.helm,
+                       msg='Please specify a valid Helm chart',
+                       check_dir=False)
+        metadata[META_ENTRY_HELM_DEFINITIONS_KEY] = args.helm
 
     if(args.manifest):
         check_file_dir(root=source,


### PR DESCRIPTION
Hi,

I didn't see any contributing guidelines so I hope this pull request is ok.
My company needs a csar file generator in our CI flow, we use helm charts so I'm updating the cli to be able to take in helm charts and store them in the correct location.